### PR TITLE
Disallowed strings and arrays in math expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - String characters indexing
 
+### Fixed
+
+- Disallowed strings and arrays in math expressions
+
 ## 0.5.0 - 2024-02-23
 
 ### Added

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -198,7 +198,7 @@ impl From<Type> for Expression<'_> {
             Type::Str => Self::Literal(Literal::Str(Vec::new())),
             Type::Array { len, elements_type } => {
                 let mut elements = Vec::<Expression<'_>>::with_capacity(len);
-                for _ in 1..len {
+                for _ in 0..=len {
                     let inner_typ = *elements_type.clone();
                     elements.push(inner_typ.into());
                 }
@@ -617,13 +617,12 @@ impl<'src, 'tokens: 'src> Ast<'src, 'tokens> {
 // iteration over tokens
 impl<'src, 'tokens: 'src> Ast<'src, 'tokens> {
     fn current_token_bounded(&self, expected: ExpectedBeforeEof) -> Result<&'tokens Token<'src>, Error<'src>> {
-        match self.tokens.get(self.token) {
-            Some(token) => Ok(token),
-            None => {
-                let previous = self.peek_previous_token();
-                Err(Error::new(self.src, previous.col, previous.kind.len(), ErrorKind::NoMoreTokens(expected)))
-            }
-        }
+        let Some(token) = self.tokens.get(self.token) else {
+            let previous = self.peek_previous_token();
+            return Err(Error::new(self.src, previous.col, previous.kind.len(), ErrorKind::NoMoreTokens(expected)));
+        };
+
+        Ok(token)
     }
 
     fn next_token(&mut self) -> Option<&'tokens Token<'src>> {
@@ -711,16 +710,83 @@ impl<'src, 'tokens: 'src> Ast<'src, 'tokens> {
 impl<'src, 'tokens: 'src> Ast<'src, 'tokens> {
     fn operator(&mut self, ops: &[Op]) -> Result<Option<(&'tokens Token<'src>, Op)>, Error<'src>> {
         let current_token = self.current_token_bounded(ExpectedBeforeEof::OperatorOrSemicolon)?;
-        match current_token.kind {
-            TokenKind::Op(op) => {
-                if ops.contains(&op) {
-                    let _ = self.next_token();
-                    Ok(Some((&current_token, op)))
-                } else {
-                    Ok(None)
-                }
+        let TokenKind::Op(op) = current_token.kind else {
+            return Ok(None);
+        };
+
+        if ops.contains(&op) {
+            let _ = self.next_token();
+            Ok(Some((&current_token, op)))
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn index(&mut self, var_name: &'src str, var_typ: Type) -> Result<Expression<'src>, Error<'src>> {
+        let current_token = &self.tokens[self.token];
+        let Some(open_bracket_token @ Token { kind: TokenKind::Bracket(BracketKind::OpenSquare), .. }) =
+            self.peek_next_token()
+        else {
+            return Ok(Expression::Identifier { name: var_name, typ: var_typ });
+        };
+
+        let _open_square = self.next_token();
+        let _start_of_index = self.next_token();
+
+        let index = self.expression()?;
+        let Type::Int = index.typ() else {
+            return Err(Error::new(
+                self.src,
+                open_bracket_token.col,
+                open_bracket_token.kind.len(),
+                ErrorKind::ExpectedIntegerExpressionInArrayIndex,
+            ));
+        };
+
+        let after_index_token = self.current_token_bounded(ExpectedBeforeEof::ClosingSquareBracket)?;
+        let TokenKind::Bracket(BracketKind::CloseSquare) = after_index_token.kind else {
+            let before_index_token = self.peek_previous_token();
+            return Err(Error::new(
+                self.src,
+                before_index_token.col,
+                before_index_token.kind.len(),
+                ErrorKind::MissingSquareBracketInArrayIndex,
+            ));
+        };
+
+        let elements_type = match var_typ {
+            Type::Array { elements_type, .. } => elements_type,
+            Type::Str => {
+                return Ok(Expression::ArrayIndex {
+                    var_name,
+                    element_type: Type::Char,
+                    bracket_position: self.src.position(open_bracket_token.col),
+                    index: Box::new(index),
+                })
             }
-            _ => Ok(None),
+            Type::Int | Type::Bool | Type::Infer | Type::Char => {
+                return Err(Error::new(
+                    self.src,
+                    current_token.col,
+                    current_token.kind.len(),
+                    ErrorKind::CannotIndexNonArrayType(var_typ),
+                ))
+            }
+        };
+
+        match *elements_type {
+            Type::Int | Type::Bool | Type::Infer | Type::Char | Type::Str => Ok(Expression::ArrayIndex {
+                var_name,
+                element_type: *elements_type,
+                bracket_position: self.src.position(open_bracket_token.col),
+                index: Box::new(index),
+            }),
+            Type::Array { .. } => Err(Error::new(
+                self.src,
+                current_token.col,
+                current_token.kind.len(),
+                ErrorKind::NestedArrayNotSupportedYet,
+            )),
         }
     }
 
@@ -732,75 +798,7 @@ impl<'src, 'tokens: 'src> Ast<'src, 'tokens> {
             TokenKind::False => Ok(Expression::Literal(Literal::Bool(false))),
             TokenKind::Identifier(name) => match self.resolve_type(name) {
                 None => match self.resolve_variable(name) {
-                    Some((_, _, var)) => match self.peek_next_token() {
-                        // TODO(stefano): extract index parsing function
-                        Some(open_bracket_token @ Token { kind: TokenKind::Bracket(BracketKind::OpenSquare), .. }) => {
-                            let var_name = var.name;
-                            let variable_typ = var.value.typ();
-
-                            let _open_square = self.next_token();
-                            let _start_of_index = self.next_token();
-
-                            let index = self.expression()?;
-                            match index.typ() {
-                                Type::Int => {
-                                    let after_index_token =
-                                        self.current_token_bounded(ExpectedBeforeEof::ClosingSquareBracket)?;
-
-                                    if let TokenKind::Bracket(BracketKind::CloseSquare) = after_index_token.kind {
-                                        match variable_typ {
-                                            Type::Array { elements_type, .. } => match *elements_type {
-                                                // TODO(stefano): check for indexing directly into an element of type string
-                                                Type::Int | Type::Bool | Type::Infer | Type::Char | Type::Str => {
-                                                    Ok(Expression::ArrayIndex {
-                                                        var_name,
-                                                        element_type: *elements_type,
-                                                        bracket_position: self.src.position(open_bracket_token.col),
-                                                        index: Box::new(index),
-                                                    })
-                                                }
-                                                Type::Array { .. } => Err(Error::new(
-                                                    self.src,
-                                                    current_token.col,
-                                                    current_token.kind.len(),
-                                                    ErrorKind::NestedArrayNotSupportedYet,
-                                                )),
-                                            },
-                                            Type::Str => Ok(Expression::ArrayIndex {
-                                                var_name,
-                                                element_type: Type::Char,
-                                                bracket_position: self.src.position(open_bracket_token.col),
-                                                index: Box::new(index),
-                                            }),
-                                            Type::Int | Type::Bool | Type::Infer | Type::Char => Err(Error::new(
-                                                self.src,
-                                                current_token.col,
-                                                current_token.kind.len(),
-                                                ErrorKind::CannotIndexNonArrayType(variable_typ),
-                                            )),
-                                        }
-                                    } else {
-                                        let before_index_token = self.peek_previous_token();
-                                        Err(Error::new(
-                                            self.src,
-                                            before_index_token.col,
-                                            before_index_token.kind.len(),
-                                            ErrorKind::MissingSquareBracketInArrayIndex,
-                                        ))
-                                    }
-                                }
-                                Type::Array { .. } | Type::Bool | Type::Infer | Type::Char | Type::Str => {
-                                    Err(Error::new(
-                                        self.src,
-                                        open_bracket_token.col,
-                                        open_bracket_token.kind.len(),
-                                        ErrorKind::ExpectedIntegerExpressionInArrayIndex,
-                                    ))
-                                }
-                            }
-                        }
-                        Some(_) | None => Ok(Expression::Identifier { name: var.name, typ: var.value.typ() }),
-                    },
+                    Some((_, _, var)) => self.index(var.name, var.value.typ()),
                     None => Err(Error::new(
                         self.src,
                         current_token.col,
@@ -975,17 +973,16 @@ impl<'src, 'tokens: 'src> Ast<'src, 'tokens> {
 
         while let Some((op_token, op)) = self.operator(&[Op::Pow])? {
             let rhs = self.primary_expression()?;
-            lhs = match (lhs.typ(), rhs.typ()) {
-                (Type::Int | Type::Char | Type::Bool, Type::Str) | (Type::Str, Type::Int | Type::Char | Type::Bool) => {
-                    return Err(Error::new(self.src, op_token.col, op_token.kind.len(), ErrorKind::StringsInExpression))
-                }
-                _ => Expression::Binary {
-                    lhs: Box::new(lhs),
-                    op_position: self.src.position(op_token.col),
-                    op,
-                    rhs: Box::new(rhs),
-                },
+            if matches!(lhs.typ(), Type::Str) || matches!(rhs.typ(), Type::Str) {
+                return Err(Error::new(self.src, op_token.col, op_token.kind.len(), ErrorKind::StringsInExpression));
             }
+
+            lhs = Expression::Binary {
+                lhs: Box::new(lhs),
+                op_position: self.src.position(op_token.col),
+                op,
+                rhs: Box::new(rhs),
+            };
         }
 
         Ok(lhs)
@@ -996,17 +993,16 @@ impl<'src, 'tokens: 'src> Ast<'src, 'tokens> {
 
         while let Some((op_token, op)) = self.operator(&[Op::Times, Op::Divide, Op::Remainder])? {
             let rhs = self.exponentiative_expression()?;
-            lhs = match (lhs.typ(), rhs.typ()) {
-                (Type::Int | Type::Char | Type::Bool, Type::Str) | (Type::Str, Type::Int | Type::Char | Type::Bool) => {
-                    return Err(Error::new(self.src, op_token.col, op_token.kind.len(), ErrorKind::StringsInExpression))
-                }
-                _ => Expression::Binary {
-                    lhs: Box::new(lhs),
-                    op_position: self.src.position(op_token.col),
-                    op,
-                    rhs: Box::new(rhs),
-                },
+            if matches!(lhs.typ(), Type::Str) || matches!(rhs.typ(), Type::Str) {
+                return Err(Error::new(self.src, op_token.col, op_token.kind.len(), ErrorKind::StringsInExpression));
             }
+
+            lhs = Expression::Binary {
+                lhs: Box::new(lhs),
+                op_position: self.src.position(op_token.col),
+                op,
+                rhs: Box::new(rhs),
+            };
         }
 
         Ok(lhs)
@@ -1017,17 +1013,16 @@ impl<'src, 'tokens: 'src> Ast<'src, 'tokens> {
 
         while let Some((op_token, op)) = self.operator(&[Op::Plus, Op::Minus])? {
             let rhs = self.multiplicative_expression()?;
-            lhs = match (lhs.typ(), rhs.typ()) {
-                (Type::Int | Type::Char | Type::Bool, Type::Str) | (Type::Str, Type::Int | Type::Char | Type::Bool) => {
-                    return Err(Error::new(self.src, op_token.col, op_token.kind.len(), ErrorKind::StringsInExpression))
-                }
-                _ => Expression::Binary {
-                    lhs: Box::new(lhs),
-                    op_position: self.src.position(op_token.col),
-                    op,
-                    rhs: Box::new(rhs),
-                },
+            if matches!(lhs.typ(), Type::Str) || matches!(rhs.typ(), Type::Str) {
+                return Err(Error::new(self.src, op_token.col, op_token.kind.len(), ErrorKind::StringsInExpression));
             }
+
+            lhs = Expression::Binary {
+                lhs: Box::new(lhs),
+                op_position: self.src.position(op_token.col),
+                op,
+                rhs: Box::new(rhs),
+            };
         }
 
         Ok(lhs)
@@ -1038,17 +1033,16 @@ impl<'src, 'tokens: 'src> Ast<'src, 'tokens> {
 
         while let Some((op_token, op)) = self.operator(&[Op::LeftShift, Op::RightShift])? {
             let rhs = self.additive_expression()?;
-            lhs = match (lhs.typ(), rhs.typ()) {
-                (Type::Int | Type::Char | Type::Bool, Type::Str) | (Type::Str, Type::Int | Type::Char | Type::Bool) => {
-                    return Err(Error::new(self.src, op_token.col, op_token.kind.len(), ErrorKind::StringsInExpression))
-                }
-                _ => Expression::Binary {
-                    lhs: Box::new(lhs),
-                    op_position: self.src.position(op_token.col),
-                    op,
-                    rhs: Box::new(rhs),
-                },
+            if matches!(lhs.typ(), Type::Str) || matches!(rhs.typ(), Type::Str) {
+                return Err(Error::new(self.src, op_token.col, op_token.kind.len(), ErrorKind::StringsInExpression));
             }
+
+            lhs = Expression::Binary {
+                lhs: Box::new(lhs),
+                op_position: self.src.position(op_token.col),
+                op,
+                rhs: Box::new(rhs),
+            };
         }
 
         Ok(lhs)
@@ -1059,17 +1053,16 @@ impl<'src, 'tokens: 'src> Ast<'src, 'tokens> {
 
         while let Some((op_token, op)) = self.operator(&[Op::BitAnd])? {
             let rhs = self.shift_expression()?;
-            lhs = match (lhs.typ(), rhs.typ()) {
-                (Type::Int | Type::Char | Type::Bool, Type::Str) | (Type::Str, Type::Int | Type::Char | Type::Bool) => {
-                    return Err(Error::new(self.src, op_token.col, op_token.kind.len(), ErrorKind::StringsInExpression))
-                }
-                _ => Expression::Binary {
-                    lhs: Box::new(lhs),
-                    op_position: self.src.position(op_token.col),
-                    op,
-                    rhs: Box::new(rhs),
-                },
+            if matches!(lhs.typ(), Type::Str) || matches!(rhs.typ(), Type::Str) {
+                return Err(Error::new(self.src, op_token.col, op_token.kind.len(), ErrorKind::StringsInExpression));
             }
+
+            lhs = Expression::Binary {
+                lhs: Box::new(lhs),
+                op_position: self.src.position(op_token.col),
+                op,
+                rhs: Box::new(rhs),
+            };
         }
 
         Ok(lhs)
@@ -1080,17 +1073,16 @@ impl<'src, 'tokens: 'src> Ast<'src, 'tokens> {
 
         while let Some((op_token, op)) = self.operator(&[Op::BitXor])? {
             let rhs = self.bitand_expression()?;
-            lhs = match (lhs.typ(), rhs.typ()) {
-                (Type::Int | Type::Char | Type::Bool, Type::Str) | (Type::Str, Type::Int | Type::Char | Type::Bool) => {
-                    return Err(Error::new(self.src, op_token.col, op_token.kind.len(), ErrorKind::StringsInExpression))
-                }
-                _ => Expression::Binary {
-                    lhs: Box::new(lhs),
-                    op_position: self.src.position(op_token.col),
-                    op,
-                    rhs: Box::new(rhs),
-                },
+            if matches!(lhs.typ(), Type::Str) || matches!(rhs.typ(), Type::Str) {
+                return Err(Error::new(self.src, op_token.col, op_token.kind.len(), ErrorKind::StringsInExpression));
             }
+
+            lhs = Expression::Binary {
+                lhs: Box::new(lhs),
+                op_position: self.src.position(op_token.col),
+                op,
+                rhs: Box::new(rhs),
+            };
         }
 
         Ok(lhs)
@@ -1101,17 +1093,16 @@ impl<'src, 'tokens: 'src> Ast<'src, 'tokens> {
 
         while let Some((op_token, op)) = self.operator(&[Op::BitOr])? {
             let rhs = self.bitxor_expression()?;
-            lhs = match (lhs.typ(), rhs.typ()) {
-                (Type::Int | Type::Char | Type::Bool, Type::Str) | (Type::Str, Type::Int | Type::Char | Type::Bool) => {
-                    return Err(Error::new(self.src, op_token.col, op_token.kind.len(), ErrorKind::StringsInExpression))
-                }
-                _ => Expression::Binary {
-                    lhs: Box::new(lhs),
-                    op_position: self.src.position(op_token.col),
-                    op,
-                    rhs: Box::new(rhs),
-                },
+            if matches!(lhs.typ(), Type::Str) || matches!(rhs.typ(), Type::Str) {
+                return Err(Error::new(self.src, op_token.col, op_token.kind.len(), ErrorKind::StringsInExpression));
             }
+
+            lhs = Expression::Binary {
+                lhs: Box::new(lhs),
+                op_position: self.src.position(op_token.col),
+                op,
+                rhs: Box::new(rhs),
+            };
         }
 
         Ok(lhs)
@@ -1122,17 +1113,16 @@ impl<'src, 'tokens: 'src> Ast<'src, 'tokens> {
 
         while let Some((op_token, op)) = self.operator(&[Op::Compare])? {
             let rhs = self.bitor_expression()?;
-            lhs = match (lhs.typ(), rhs.typ()) {
-                (Type::Int | Type::Char | Type::Bool, Type::Str) | (Type::Str, Type::Int | Type::Char | Type::Bool) => {
-                    return Err(Error::new(self.src, op_token.col, op_token.kind.len(), ErrorKind::StringsInExpression))
-                }
-                _ => Expression::Binary {
-                    lhs: Box::new(lhs),
-                    op_position: self.src.position(op_token.col),
-                    op,
-                    rhs: Box::new(rhs),
-                },
+            if matches!(lhs.typ(), Type::Str) || matches!(rhs.typ(), Type::Str) {
+                return Err(Error::new(self.src, op_token.col, op_token.kind.len(), ErrorKind::StringsInExpression));
             }
+
+            lhs = Expression::Binary {
+                lhs: Box::new(lhs),
+                op_position: self.src.position(op_token.col),
+                op,
+                rhs: Box::new(rhs),
+            };
         }
 
         Ok(lhs)
@@ -1167,14 +1157,14 @@ impl<'src, 'tokens: 'src> Ast<'src, 'tokens> {
         let mut lhs = self.comparison_expression()?;
 
         while let Some((op_token, op)) = self.operator(&[Op::And])? {
-            if lhs.typ() != Type::Bool {
+            let Type::Bool = lhs.typ() else {
                 return Err(Error::new(self.src, op_token.col, op_token.kind.len(), ErrorKind::NonBooleanLeftOperand));
-            }
+            };
 
             let rhs = self.comparison_expression()?;
-            if rhs.typ() != Type::Bool {
+            let Type::Bool = rhs.typ() else {
                 return Err(Error::new(self.src, op_token.col, op_token.kind.len(), ErrorKind::NonBooleanRightOperand));
-            }
+            };
 
             lhs = Expression::Binary {
                 lhs: Box::new(lhs),
@@ -1191,14 +1181,14 @@ impl<'src, 'tokens: 'src> Ast<'src, 'tokens> {
         let mut lhs = self.and_expression()?;
 
         while let Some((op_token, op)) = self.operator(&[Op::Or])? {
-            if lhs.typ() != Type::Bool {
+            let Type::Bool = lhs.typ() else {
                 return Err(Error::new(self.src, op_token.col, op_token.kind.len(), ErrorKind::NonBooleanLeftOperand));
-            }
+            };
 
             let rhs = self.and_expression()?;
-            if rhs.typ() != Type::Bool {
+            let Type::Bool = rhs.typ() else {
                 return Err(Error::new(self.src, op_token.col, op_token.kind.len(), ErrorKind::NonBooleanRightOperand));
-            }
+            };
 
             lhs = Expression::Binary {
                 lhs: Box::new(lhs),
@@ -1261,68 +1251,63 @@ impl<'src, 'tokens: 'src> Ast<'src, 'tokens> {
 
     fn type_annotation(&mut self) -> Result<Option<(&'tokens Token<'src>, Type)>, Error<'src>> {
         let colon_token = self.next_token_bounded(ExpectedBeforeEof::TypeAnnotationOrVariableDefinition)?;
-        if let TokenKind::Colon = &colon_token.kind {
-            let type_token = self.next_token_bounded(ExpectedBeforeEof::TypeAnnotation)?;
-            match &type_token.kind {
-                TokenKind::Identifier(type_name) => match self.resolve_type(type_name) {
-                    Some(typ) => match self.peek_next_token() {
-                        Some(
-                            open_square_bracket_token @ Token {
-                                kind: TokenKind::Bracket(BracketKind::OpenSquare), ..
-                            },
-                        ) => {
-                            let elements_type = Box::new(typ.clone());
-                            let _ = self.next_token();
-                            let len_token = self.next_token_bounded(ExpectedBeforeEof::ArrayLength)?;
-                            match len_token.kind {
-                                TokenKind::Literal(Literal::Int(len)) => match self.next_token() {
-                                    Some(
-                                        close_square_bracket_token @ Token {
-                                            kind: TokenKind::Bracket(BracketKind::CloseSquare),
-                                            ..
-                                        },
-                                    ) => Ok(Some((
-                                        close_square_bracket_token,
-                                        Type::Array { len: len as usize, elements_type },
-                                    ))),
-                                    Some(_) | None => Err(Error::new(
-                                        self.src,
-                                        open_square_bracket_token.col,
-                                        open_square_bracket_token.kind.len(),
-                                        ErrorKind::MissingSquareBracketInArrayTypeAnnotation,
-                                    )),
-                                },
-                                TokenKind::Bracket(BracketKind::CloseSquare) => Err(Error::new(
-                                    self.src,
-                                    len_token.col,
-                                    len_token.kind.len(),
-                                    ErrorKind::MissingArrayLength,
-                                )),
-                                _ => Err(Error::new(
-                                    self.src,
-                                    len_token.col,
-                                    len_token.kind.len(),
-                                    ErrorKind::NonLiteralIntegerArrayLength,
-                                )),
-                            }
-                        }
-                        Some(_) | None => Ok(Some((type_token, typ.clone()))),
-                    },
-                    None => match self.resolve_variable(type_name) {
-                        Some((_, _, var)) => Ok(Some((type_token, var.value.typ()))),
-                        None => Err(Error::new(
-                            self.src,
-                            type_token.col,
-                            type_token.kind.len(),
-                            ErrorKind::VariableAsTypeAnnotationNotPreviouslyDefined,
-                        )),
-                    },
-                },
-                _ => Err(Error::new(self.src, colon_token.col, colon_token.kind.len(), ErrorKind::ExpectedTypeName)),
-            }
-        } else {
+        let TokenKind::Colon = colon_token.kind else {
             self.token -= 1;
-            Ok(None)
+            return Ok(None);
+        };
+
+        let type_token = self.next_token_bounded(ExpectedBeforeEof::TypeAnnotation)?;
+        let TokenKind::Identifier(type_name) = type_token.kind else {
+            return Err(Error::new(self.src, colon_token.col, colon_token.kind.len(), ErrorKind::ExpectedTypeName));
+        };
+
+        let Some(typ) = self.resolve_type(type_name) else {
+            return match self.resolve_variable(type_name) {
+                Some((_, _, var)) => Ok(Some((type_token, var.value.typ()))),
+                None => Err(Error::new(
+                    self.src,
+                    type_token.col,
+                    type_token.kind.len(),
+                    ErrorKind::VariableAsTypeAnnotationNotPreviouslyDefined,
+                )),
+            };
+        };
+
+        let Some(open_square_bracket_token @ Token { kind: TokenKind::Bracket(BracketKind::OpenSquare), .. }) =
+            self.peek_next_token()
+        else {
+            return Ok(Some((type_token, typ.clone())));
+        };
+
+        let elements_type = Box::new(typ.clone());
+        let _open_square_bracket = self.next_token();
+
+        let len_token = self.next_token_bounded(ExpectedBeforeEof::ArrayLength)?;
+        let len = match len_token.kind {
+            TokenKind::Literal(Literal::Int(len)) => len,
+            TokenKind::Bracket(BracketKind::CloseSquare) => {
+                return Err(Error::new(self.src, len_token.col, len_token.kind.len(), ErrorKind::MissingArrayLength))
+            }
+            _ => {
+                return Err(Error::new(
+                    self.src,
+                    len_token.col,
+                    len_token.kind.len(),
+                    ErrorKind::NonLiteralIntegerArrayLength,
+                ))
+            }
+        };
+
+        match self.next_token() {
+            Some(close_square_bracket_token @ Token { kind: TokenKind::Bracket(BracketKind::CloseSquare), .. }) => {
+                Ok(Some((close_square_bracket_token, Type::Array { len: len as usize, elements_type })))
+            }
+            Some(_) | None => Err(Error::new(
+                self.src,
+                open_square_bracket_token.col,
+                open_square_bracket_token.kind.len(),
+                ErrorKind::MissingSquareBracketInArrayTypeAnnotation,
+            )),
         }
     }
 
@@ -1491,18 +1476,8 @@ impl<'src, 'tokens: 'src> Ast<'src, 'tokens> {
 // print statements
 impl<'src, 'tokens: 'src> Ast<'src, 'tokens> {
     fn print(&mut self) -> Result<Node<'src>, Error<'src>> {
-        let start_of_expression_token = self.next_token_bounded(ExpectedBeforeEof::Expression)?;
-        let argument = self.expression()?;
-        if let Expression::Array { .. } = argument {
-            return Err(Error::new(
-                self.src,
-                start_of_expression_token.col,
-                start_of_expression_token.kind.len(),
-                ErrorKind::TemporaryArrayNotSupportedYet,
-            ));
-        }
-
-        Ok(Node::Print(argument))
+        let arg = self.print_arg()?;
+        Ok(Node::Print(arg))
     }
 
     fn println(&mut self) -> Result<Node<'src>, Error<'src>> {
@@ -1511,18 +1486,23 @@ impl<'src, 'tokens: 'src> Ast<'src, 'tokens> {
             return Ok(Node::Println(None));
         }
 
+        let arg = self.print_arg()?;
+        Ok(Node::Println(Some(arg)))
+    }
+
+    fn print_arg(&mut self) -> Result<Expression<'src>, Error<'src>> {
         let start_of_expression_token = self.next_token_bounded(ExpectedBeforeEof::Expression)?;
         let argument = self.expression()?;
-        if let Expression::Array { .. } = argument {
-            return Err(Error::new(
-                self.src,
-                start_of_expression_token.col,
-                start_of_expression_token.kind.len(),
-                ErrorKind::TemporaryArrayNotSupportedYet,
-            ));
-        }
+        let Expression::Array { .. } = argument else {
+            return Ok(argument);
+        };
 
-        Ok(Node::Println(Some(argument)))
+        Err(Error::new(
+            self.src,
+            start_of_expression_token.col,
+            start_of_expression_token.kind.len(),
+            ErrorKind::TemporaryArrayNotSupportedYet,
+        ))
     }
 }
 
@@ -1778,7 +1758,7 @@ pub enum ErrorKind {
     CannotInvertArray,
     KeywordInExpression,
     ExpectedOperand,
-    StringsInExpression,
+    StringsInExpression, // TODO(breaking)(stefano): split into StringLeftOperand and StringRightOperand
     ChainedComparison,
     NonBooleanLeftOperand,
     NonBooleanRightOperand,

--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -958,7 +958,7 @@ impl<'src, 'ast: 'src> Compiler<'src, 'ast> {
                             "rsi",
                             format!(
                                 " push rdi\
-                                \n mov rdi, rsi
+                                \n mov rdi, rsi\
                                 \n mov rdx, {line}\
                                 \n mov rcx, {col}\
                                 \n call assert_modulo_not_zero\

--- a/src/main.rs
+++ b/src/main.rs
@@ -190,7 +190,7 @@ mod tests {
                     if path == "features_test.kay" {
                         continue;
                     }
-                },
+                }
                 None => continue,
             }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -173,13 +173,26 @@ mod tests {
 
         for src_file in src_files {
             let src_path = src_file?.path();
+            if src_path.is_dir() {
+                continue;
+            }
+
             let Some(extension) = src_path.extension() else {
                 continue;
             };
 
             if extension != "kay" {
                 continue;
-            };
+            }
+
+            match src_path.file_name() {
+                Some(path) => {
+                    if path == "features_test.kay" {
+                        continue;
+                    }
+                },
+                None => continue,
+            }
 
             let execution_step = Step { start_time: Instant::now(), verbosity };
 

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -458,31 +458,31 @@ impl<'src> Tokenizer<'src> {
                 }
 
                 if contains_non_ascii {
-                    Err(Error::new(
+                    return Err(Error::new(
                         self.src,
                         self.token_start_col,
                         self.col - self.token_start_col + 1,
                         ErrorKind::NonAsciiIdentifier,
-                    ))
-                } else {
-                    let identifier = match &self.src.code[self.token_start_col..self.col] {
-                        "let" => TokenKind::Definition(Mutability::Let),
-                        "var" => TokenKind::Definition(Mutability::Var),
-                        "print" => TokenKind::Print,
-                        "println" => TokenKind::PrintLn,
-                        "true" => TokenKind::True,
-                        "false" => TokenKind::False,
-                        "do" => TokenKind::Do,
-                        "if" => TokenKind::If,
-                        "else" => TokenKind::Else,
-                        "loop" => TokenKind::Loop,
-                        "break" => TokenKind::Break,
-                        "continue" => TokenKind::Continue,
-                        identifier => TokenKind::Identifier(identifier),
-                    };
-
-                    Ok(identifier)
+                    ));
                 }
+
+                let identifier = match &self.src.code[self.token_start_col..self.col] {
+                    "let" => TokenKind::Definition(Mutability::Let),
+                    "var" => TokenKind::Definition(Mutability::Var),
+                    "print" => TokenKind::Print,
+                    "println" => TokenKind::PrintLn,
+                    "true" => TokenKind::True,
+                    "false" => TokenKind::False,
+                    "do" => TokenKind::Do,
+                    "if" => TokenKind::If,
+                    "else" => TokenKind::Else,
+                    "loop" => TokenKind::Loop,
+                    "break" => TokenKind::Break,
+                    "continue" => TokenKind::Continue,
+                    identifier => TokenKind::Identifier(identifier),
+                };
+
+                Ok(identifier)
             }
             b'0'..=b'9' => {
                 let mut contains_non_ascii = false;
@@ -594,18 +594,17 @@ impl<'src> Tokenizer<'src> {
                     ch => Ok(ch),
                 };
 
-                match self.peek_next_ascii_character()? {
-                    Some(b'\'') => {
-                        self.col += 1;
-                        Ok(TokenKind::Literal(Literal::Char(code?)))
-                    }
-                    Some(_) | None => Err(Error::new(
+                let Some(b'\'') = self.peek_next_ascii_character()? else {
+                    return Err(Error::new(
                         self.src,
                         self.token_start_col,
                         self.col - self.token_start_col,
                         ErrorKind::UnclosedCharacterLiteral,
-                    )),
-                }
+                    ));
+                };
+
+                self.col += 1;
+                Ok(TokenKind::Literal(Literal::Char(code?)))
             }
             b'(' => {
                 let kind = BracketKind::OpenRound;


### PR DESCRIPTION
Strings and arrays were mistakenly allowed in math expressions, and therefore would lead to bugs and crashes during the latter compilation steps.
Error messages and error kinds were therefore updated